### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/libcomxml/core/__init__.py
+++ b/libcomxml/core/__init__.py
@@ -66,7 +66,7 @@ class Field(object):
 
 
     def __str__(self):
-        return (u"<Field:%s>" % (self.name,)).encode('utf8')
+        return (u"<Field:{0!s}>".format(self.name)).encode('utf8')
 
     def __unicode__(self):
         return unicode(self.__str__(), 'utf8')
@@ -117,7 +117,7 @@ class XmlField(Field):
             elif isinstance(value, list):
                 self._parse_list(element, value)
             else:  # default: cast to unicode
-                element.text = u"%s" % value
+                element.text = u"{0!s}".format(value)
 
         return element
 
@@ -127,7 +127,7 @@ class XmlField(Field):
         :param parent: an etree Element to be used as parent for this one
         """
         if self.namespace:
-            name = '{%s}%s' % (self.namespace, self.name)
+            name = '{{{0!s}}}{1!s}'.format(self.namespace, self.name)
         else:
             name = self.name
         if parent is not None:
@@ -202,7 +202,7 @@ class Model(object):
 
 
     def __str__(self):
-        return (u"<Model:%s>" % (self.name,)).encode('utf8')
+        return (u"<Model:{0!s}>".format(self.name)).encode('utf8')
 
     def __unicode__(self):
         return unicode(self.__str__(), 'utf8')

--- a/tests/test_libcomxml.py
+++ b/tests/test_libcomxml.py
@@ -76,7 +76,7 @@ class TestFields(unittest.TestCase):
                                                      grouping=True)
         self.assertEqual(formated, self.field.element().text)
         self.assertEqual(str(self.field),
-                         '<Quantity uom="unit">%s</Quantity>' % formated)
+                         '<Quantity uom="unit">{0!s}</Quantity>'.format(formated))
 
     def test_update_attributes(self):
         self.field.attributes.update({'uom': 'kg'})


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:gisce:libComXML?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:gisce:libComXML?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)