### PR TITLE
Add python3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
 - '2.7'
+- '3.5'
 install:
 - pip install .
 - pip install coveralls

--- a/libcomxml/__init__.py
+++ b/libcomxml/__init__.py
@@ -5,5 +5,5 @@
 try:
     __version__ = __import__('pkg_resources') \
         .get_distribution(__name__).version
-except Exception, e:
+except Exception:
     __version__ = 'unknown'

--- a/setup.py
+++ b/setup.py
@@ -11,5 +11,11 @@ setup(
     install_requires=['lxml', 'six'],
     license='None',
     description='This library permits XML generation from Python objects',
-    test_suite='tests'
+    test_suite='tests',
+    classifiers=[
+        'Topic :: Text Processing :: Markup :: XML',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.5'
+    ]
 )

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     author='GISCE Enginyeria, SL',
     author_email='devel@gisce.net',
     packages=find_packages(),
-    install_requires=['lxml'],
+    install_requires=['lxml', 'six'],
     license='None',
     description='This library permits XML generation from Python objects',
     test_suite='tests'


### PR DESCRIPTION
- Travis check tests with python3.5
- Add [six](https://pythonhosted.org/six/) dependency (Python2 - Python3 layer compatibility)
- Workarraund calling `str`

**Note for python3 users**: If you want to write the XML Content you must call to `serialize()` which returns the bytes in correct encoding, if you call `str()` the unicode is returned.

