### PR TITLE
Fix False value

### DIFF
--- a/libcomxml/core/__init__.py
+++ b/libcomxml/core/__init__.py
@@ -105,7 +105,7 @@ class XmlField(Field):
         """
         if not value:
             value = self.value
-        if value is not None:
+        if value is not None and value is not False:
             if six.PY2 and isinstance(value, str):
                 element.text = unicode(value, 'utf8')
             elif isinstance(value, XmlField):

--- a/tests/test_libcomxml.py
+++ b/tests/test_libcomxml.py
@@ -13,8 +13,8 @@ import sys
 _ROOT = os.path.abspath(os.path.dirname(__file__))
 
 
-if sys.version_info[0] < 3:
-    # python2
+class XMLTest(unittest.TestCase):
+
     def assertXmlEqual(self, got, want):
         from lxml.doctestcompare import LXMLOutputChecker
         from doctest import Example
@@ -25,10 +25,6 @@ if sys.version_info[0] < 3:
         message = checker.output_difference(Example("", want), got, 0)
         raise AssertionError(message)
 
-    unittest.TestCase.assertXmlEqual = assertXmlEqual
-else:
-    # python3
-    unittest.TestCase.assertXmlEqual = unittest.TestCase.assertEqual
 
 class Cd(XmlModel):
 
@@ -109,11 +105,10 @@ class TestFields(unittest.TestCase):
         self.assertEqual(self.field.element().items(), [('uom', 'kg')])
 
 
-class TestModel(unittest.TestCase):
+class TestModel(XMLTest):
 
     def setUp(self):
-        self.xml = "<?xml version='1.0' encoding='UTF-8'?>\n"
-        self.xml += re.sub('\s+<', '<', """
+        self.xml = re.sub('\s+<', '<', """
 <CATALOG>
     <CD>
         <ARTIST>Bob Dylan</ARTIST>
@@ -174,21 +169,16 @@ class TestModel(unittest.TestCase):
         self.catalog.build_tree()
 
     def test_xml(self):
-        with open('/tmp/x1.xml', 'wb') as f:
-            f.write(self.xml.encode('utf8'))
-        with open('/tmp/x2.xml', 'wb') as f:
-            f.write(self.catalog.serialize())
-        self.assertXmlEqual(self.xml.encode('utf8'), self.catalog.serialize())
+        self.assertXmlEqual(self.xml, str(self.catalog))
 
 
-class TestEmpty(unittest.TestCase):
+class TestEmpty(XMLTest):
 
     def setUp(self):
-        self.xml = "<?xml version='1.0' encoding='UTF-8'?>\n<feed>"
+        self.xml = "<feed>"
         self.xml += "<test>foo</test><link href=\"http://example.com\"/>"
         self.xml += "<entry><val>1</val></entry><entry><val>2</val></entry>"
         self.xml += "</feed>"
-        self.xml = self.xml.encode('utf8')
 
     def test_empty(self):
 
@@ -219,10 +209,10 @@ class TestEmpty(unittest.TestCase):
 
         feed.build_tree()
 
-        self.assertXmlEqual(self.xml, feed.serialize())
+        self.assertXmlEqual(self.xml, str(feed))
 
 
-class TestValue(unittest.TestCase):
+class TestValue(XMLTest):
     value = None
 
     def _test_drop(self, drop_empty=False, xml=None):
@@ -253,26 +243,24 @@ class TestValue(unittest.TestCase):
 
         feed.build_tree()
 
-        self.assertXmlEqual(xml, feed.serialize())
+        self.assertXmlEqual(xml, str(feed))
 
 
 class TestZeroValue(TestValue):
     value = 0
 
     def test_drop_empty_disabled(self):
-        xml = "<?xml version='1.0' encoding='UTF-8'?>\n<feed>"
+        xml = "<feed>"
         xml += "<test>foo</test><link href=\"http://example.com\"/>"
         xml += "<entry><val>1</val></entry><entry><val>0</val></entry>"
         xml += "</feed>"
-        xml = xml.encode('utf8')
         self._test_drop(False, xml)
 
     def test_drop_empty_enabled(self):
-        xml = "<?xml version='1.0' encoding='UTF-8'?>\n<feed>"
+        xml = "<feed>"
         xml += "<test>foo</test>"
         xml += "<entry><val>1</val></entry><entry><val>0</val></entry>"
         xml += "</feed>"
-        xml = xml.encode('utf8')
         self._test_drop(True, xml)
 
 
@@ -280,19 +268,17 @@ class TestFalseValue(TestValue):
     value = False
 
     def test_false_drop_empty_disabled(self):
-        xml = "<?xml version='1.0' encoding='UTF-8'?>\n<feed>"
+        xml = "<feed>"
         xml += "<test>foo</test><link href=\"http://example.com\"/>"
         xml += "<entry><val>1</val></entry><entry/>"
         xml += "</feed>"
-        xml = xml.encode('utf8')
         self._test_drop(False, xml)
 
     def test_false_drop_empty_enabled(self):
-        xml = "<?xml version='1.0' encoding='UTF-8'?>\n<feed>"
+        xml = "<feed>"
         xml += "<test>foo</test>"
         xml += "<entry><val>1</val></entry>"
         xml += "</feed>"
-        xml = xml.encode('utf8')
         self._test_drop(True, xml)
 
 
@@ -300,27 +286,24 @@ class TestNoneValue(TestValue):
     value = None
 
     def test_drop_empty_disabled(self):
-        xml = "<?xml version='1.0' encoding='UTF-8'?>\n<feed>"
+        xml = "<feed>"
         xml += "<test>foo</test><link href=\"http://example.com\"/>"
         xml += "<entry><val>1</val></entry><entry/>"
         xml += "</feed>"
-        xml = xml.encode('utf8')
         self._test_drop(False, xml)
 
     def test_drop_empty_enabled(self):
-        xml = "<?xml version='1.0' encoding='UTF-8'?>\n<feed>"
+        xml = "<feed>"
         xml += "<test>foo</test>"
         xml += "<entry><val>1</val></entry>"
         xml += "</feed>"
-        xml = xml.encode('utf8')
         self._test_drop(True, xml)
 
-class RootWithAttributes(unittest.TestCase):
+
+class RootWithAttributes(XMLTest):
 
     def setUp(self):
-        self.xml = "<?xml version='1.0' encoding='UTF-8'?>\n"
-        self.xml += "<link href=\"http://example.com\"/>"
-        self.xml = self.xml.encode('utf8')
+        self.xml = "<link href=\"http://example.com\"/>"
 
     def test_root_with_attributes(self):
 
@@ -336,13 +319,12 @@ class RootWithAttributes(unittest.TestCase):
         l.tag.attributes.update({'href': 'http://example.com'})
         l.build_tree()
 
-        self.assertXmlEqual(self.xml, l.serialize())
+        self.assertXmlEqual(self.xml, str(l))
 
 
-class Namespaces(unittest.TestCase):
+class Namespaces(XMLTest):
     def setUp(self):
-        self.xml = "<?xml version='1.0' encoding='UTF-8'?>\n"
-        self.xml += "<rss "
+        self.xml = "<rss "
         self.xml += "xmlns:atom=\"http://www.w3.org/2005/Atom\" "
         self.xml += "xmlns:opensearch=\"http://a9.com/-/spec/opensearch/1.1/\" "
         self.xml += "version=\"2.0\">"
@@ -354,7 +336,6 @@ class Namespaces(unittest.TestCase):
         self.xml += "<opensearch:totalResults>4230000</opensearch:totalResults>"
         self.xml += "</channel>"
         self.xml += "</rss>"
-        self.xml = self.xml.encode('utf8')
 
     def test_namesapces_root(self):
 
@@ -404,6 +385,6 @@ class Namespaces(unittest.TestCase):
         rss.build_tree()
 
         self.assertXmlEqual(
-            self.xml, rss.serialize()
+            self.xml, str(rss)
         )
 

--- a/tests/test_libcomxml.py
+++ b/tests/test_libcomxml.py
@@ -7,6 +7,21 @@ import unittest
 import locale
 import re
 from libcomxml.core import XmlField, XmlModel, clean_xml
+import os
+
+_ROOT = os.path.abspath(os.path.dirname(__file__))
+
+def assertXmlEqual(self, got, want):
+    from lxml.doctestcompare import LXMLOutputChecker
+    from doctest import Example
+
+    checker = LXMLOutputChecker()
+    if checker.check_output(want, got, 0):
+        return
+    message = checker.output_difference(Example("", want), got, 0)
+    raise AssertionError(message)
+
+unittest.TestCase.assertXmlEqual = assertXmlEqual
 
 
 class Cd(XmlModel):
@@ -157,7 +172,7 @@ class TestModel(unittest.TestCase):
             f.write(self.xml.encode('utf8'))
         with open('/tmp/x2.xml', 'wb') as f:
             f.write(self.catalog.serialize())
-        self.assertEqual(self.xml.encode('utf8'), self.catalog.serialize())
+        self.assertXmlEqual(self.xml.encode('utf8'), self.catalog.serialize())
 
 
 class TestEmpty(unittest.TestCase):
@@ -198,7 +213,7 @@ class TestEmpty(unittest.TestCase):
 
         feed.build_tree()
 
-        self.assertEqual(self.xml, feed.serialize())
+        self.assertXmlEqual(self.xml, feed.serialize())
 
 
 class TestValue(unittest.TestCase):
@@ -232,7 +247,7 @@ class TestValue(unittest.TestCase):
 
         feed.build_tree()
 
-        self.assertEqual(xml, feed.serialize())
+        self.assertXmlEqual(xml, feed.serialize())
 
 
 class TestZeroValue(TestValue):
@@ -295,7 +310,7 @@ class RootWithAttributes(unittest.TestCase):
         l.tag.attributes.update({'href': 'http://example.com'})
         l.build_tree()
 
-        self.assertEqual(self.xml, l.serialize())
+        self.assertXmlEqual(self.xml, l.serialize())
 
 
 class Namespaces(unittest.TestCase):
@@ -362,7 +377,7 @@ class Namespaces(unittest.TestCase):
         })
         rss.build_tree()
 
-        self.assertEqual(
+        self.assertXmlEqual(
             self.xml, rss.serialize()
         )
 

--- a/tests/test_libcomxml.py
+++ b/tests/test_libcomxml.py
@@ -8,21 +8,27 @@ import locale
 import re
 from libcomxml.core import XmlField, XmlModel, clean_xml
 import os
+import sys
 
 _ROOT = os.path.abspath(os.path.dirname(__file__))
 
-def assertXmlEqual(self, got, want):
-    from lxml.doctestcompare import LXMLOutputChecker
-    from doctest import Example
 
-    checker = LXMLOutputChecker()
-    if checker.check_output(want, got, 0):
-        return
-    message = checker.output_difference(Example("", want), got, 0)
-    raise AssertionError(message)
+if sys.version_info[0] < 3:
+    # python2
+    def assertXmlEqual(self, got, want):
+        from lxml.doctestcompare import LXMLOutputChecker
+        from doctest import Example
 
-unittest.TestCase.assertXmlEqual = assertXmlEqual
+        checker = LXMLOutputChecker()
+        if checker.check_output(want, got, 0):
+            return
+        message = checker.output_difference(Example("", want), got, 0)
+        raise AssertionError(message)
 
+    unittest.TestCase.assertXmlEqual = assertXmlEqual
+else:
+    # python3
+    unittest.TestCase.assertXmlEqual = unittest.TestCase.assertEqual
 
 class Cd(XmlModel):
 
@@ -276,7 +282,7 @@ class TestFalseValue(TestValue):
     def test_false_drop_empty_disabled(self):
         xml = "<?xml version='1.0' encoding='UTF-8'?>\n<feed>"
         xml += "<test>foo</test><link href=\"http://example.com\"/>"
-        xml += "<entry><val>1</val></entry><entry></entry>"
+        xml += "<entry><val>1</val></entry><entry/>"
         xml += "</feed>"
         xml = xml.encode('utf8')
         self._test_drop(False, xml)

--- a/tests/test_libcomxml.py
+++ b/tests/test_libcomxml.py
@@ -270,6 +270,26 @@ class TestZeroValue(TestValue):
         self._test_drop(True, xml)
 
 
+class TestFalseValue(TestValue):
+    value = False
+
+    def test_false_drop_empty_disabled(self):
+        xml = "<?xml version='1.0' encoding='UTF-8'?>\n<feed>"
+        xml += "<test>foo</test><link href=\"http://example.com\"/>"
+        xml += "<entry><val>1</val></entry><entry></entry>"
+        xml += "</feed>"
+        xml = xml.encode('utf8')
+        self._test_drop(False, xml)
+
+    def test_false_drop_empty_enabled(self):
+        xml = "<?xml version='1.0' encoding='UTF-8'?>\n<feed>"
+        xml += "<test>foo</test>"
+        xml += "<entry><val>1</val></entry>"
+        xml += "</feed>"
+        xml = xml.encode('utf8')
+        self._test_drop(True, xml)
+
+
 class TestNoneValue(TestValue):
     value = None
 


### PR DESCRIPTION
When a Boolean False value:

* **drop empy**: Do not export the tag and if empty, drops the parent too
* **No drop empty**: Do not exports the tag but mantains parent tag